### PR TITLE
Show QR code for offsites

### DIFF
--- a/cypress/e2e/offsite.cy.js
+++ b/cypress/e2e/offsite.cy.js
@@ -18,6 +18,8 @@ describe('KOMOJU Fields: Offsites', () => {
   it('renders no fields for PayPay', () => {
     cy.visit('/type/paypay');
 
+    cy.get('komoju-fields').shadow().find('img.offsite-qr-code').should('exist');
+
     cy.wait(1000);
     cy.get('komoju-fields').shadow().find('input').should('not.exist');
 

--- a/src/fields/offsite/i18n.ts
+++ b/src/fields/offsite/i18n.ts
@@ -3,6 +3,7 @@ export const en = {
   'os.label.email': 'Email address',
   'os.label.phone': 'Phone number',
   'os.error.required': 'Required',
+  'os.pay-with-qr': 'Optional: scan QR code to pay via mobile app.',
 };
 
 export const ja: typeof en = {
@@ -10,4 +11,5 @@ export const ja: typeof en = {
   'os.label.email': 'メールアドレス',
   'os.label.phone': '電話番号',
   'os.error.required': '必須項目です',
+  'os.pay-with-qr': '任意：QRコードをスキャンし、スマホで決済を行うことができます。',
 };

--- a/src/fields/offsite/template.html
+++ b/src/fields/offsite/template.html
@@ -1,4 +1,7 @@
-<div class="fields">
+<div class="fields offsite">
+  <img class="offsite-qr-code">
+  <komoju-i18n class="qr-code-explanation" key="os.pay-with-qr"></komoju-i18n>
+
   <template id="additional-field">
     <label class="field">
       <komoju-i18n></komoju-i18n>
@@ -6,3 +9,20 @@
     </label>
   </template>
 </div>
+
+<style>
+  .offsite {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .offsite-qr-code {
+    width: 128px;
+    height: 128px;
+    border: 1px solid black;
+  }
+
+  .qr-code-explanation {
+    color: #8b99a7;
+  }
+</style>


### PR DESCRIPTION
I'm not sure if we want this on by default or not, so I'm leaving it in a PR for now.

This PR makes offsite payment methods show a QR code.
![image](https://user-images.githubusercontent.com/2793160/204548877-78b13c4b-f556-46aa-b8b4-e73456e990af.png)

Scanning the QR code and completing payment on your phone will automatically transition the browser to the session's return_url.

For sessions with a single payment method, the QR code will lead directly to the offsite app URL, meaning the user never sees KOMOJU.

Currently, this QR code will show up on mobile devices too. Probably should fix that if we want to move forward with this.